### PR TITLE
Update of, well, everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+env:
+  global:
+    - CODECOV_TOKEN="9cad37df-1679-4924-bd27-76e0081f96bd"
+
 language: php
 
 php:
@@ -10,7 +14,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
 
 before_script:
-  - composer self-update
-  - composer install
-  - pyrus install pear/PHP_CodeSniffer
-  - phpenv rehash
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-source --dev
 
 script:
-  - phpcs --standard=psr2 src/
-  - phpunit --coverage-text
+  - vendor/bin/phpunit --coverage-clover=coverage.xml
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Yogurt
 
-[![PHP version](https://badge.fury.io/ph/oscarpalmer%2Fyogurt.png)](http://badge.fury.io/ph/oscarpalmer%2Fyogurt) [![Build Status](https://travis-ci.org/oscarpalmer/yogurt.png?branch=master)](https://travis-ci.org/oscarpalmer/yogurt) [![Coverage Status](https://coveralls.io/repos/oscarpalmer/yogurt/badge.png)](https://coveralls.io/r/oscarpalmer/yogurt)
+[![PHP version](https://badge.fury.io/ph/oscarpalmer%2Fyogurt.png)](http://badge.fury.io/ph/oscarpalmer%2Fyogurt) [![Build Status](https://travis-ci.org/oscarpalmer/yogurt.png?branch=master)](https://travis-ci.org/oscarpalmer/yogurt) [![Coverage Status](https://codecov.io/gh/oscarpalmer/yogurt/branch/master/graph/badge.svg)](https://codecov.io/gh/oscarpalmer/yogurt)
 
-Yogurt is a template language for PHP (`>=5.3`) inspired by [Riot's](http://riothq.com) [Hammer](http://hammerformac.com). Hammer's syntax was based on regular ol' HTML comment tags, so you won't have to install another syntax highlighter for your editor. Nice, huh?
+Yogurt is a template language for PHP (`>=5.3`) inspired by [Beach's](http://beach.io) [Hammer](http://hammerformac.com). Hammer's syntax was based on regular ol' HTML comment tags, so you won't have to install another syntax highlighter for your editor. Nice, huh?
 
 ## Getting started
 
@@ -115,7 +115,6 @@ Strings however, do need quotation marks; if they're not wrapped in quotation ma
 
 ## Todo
 
-- Update for PHP7, new PHPUnit, etc.
 - More string modifiers.
 - Adding and removing custom modifier functions.
 - Adding and removing custom parsers functions?

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=5.3.0"
   },
   "require-dev": {
-    "league/phpunit-coverage-listener": "dev-master"
+    "phpunit/phpunit": ">=6.0.0"
   },
   "type": "library"
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=5.3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=6.0.0"
+    "phpunit/phpunit": "~4.0"
   },
   "type": "library"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,33 +10,4 @@
       <directory suffix=".php">src/oscarpalmer/Yogurt</directory>
     </whitelist>
   </filter>
-  <logging>
-    <log type="coverage-clover" target="/tmp/coverage.xml"/>
-  </logging>
-  <listeners>
-    <listener class="League\PHPUnitCoverageListener\Listener">
-      <arguments>
-        <array>
-          <element key="printer">
-            <object class="League\PHPUnitCoverageListener\Printer\StdOut"/>
-          </element>
-          <element key="hook">
-            <object class="League\PHPUnitCoverageListener\Hook\Travis"/>
-          </element>
-          <element key="namespace">
-            <string>oscarpalmer\Yogurt</string>
-          </element>
-          <element key="repo_token">
-            <string>ihUE79YRFYSlDQjdwMoFDqq12E6ewNe2D</string>
-          </element>
-          <element key="target_url">
-            <string>https://coveralls.io/api/v1/jobs</string>
-          </element>
-          <element key="coverage_dir">
-            <string>/tmp</string>
-          </element>
-        </array>
-      </arguments>
-    </listener>
-  </listeners>
 </phpunit>

--- a/tests/oscarpalmer/Yogurt/Test/DairyTest.php
+++ b/tests/oscarpalmer/Yogurt/Test/DairyTest.php
@@ -11,7 +11,7 @@ use oscarpalmer\Yogurt\Dairy\Variables;
 use oscarpalmer\Yogurt\Yogurt;
 use oscarpalmer\Yogurt\Exception\Syntax;
 
-class DairyTest extends \PHPUnit_Framework_TestCase
+class DairyTest extends \PHPUnit\Framework\TestCase
 {
     # Mock variables.
     protected $directory;

--- a/tests/oscarpalmer/Yogurt/Test/FlavourTest.php
+++ b/tests/oscarpalmer/Yogurt/Test/FlavourTest.php
@@ -5,7 +5,7 @@ namespace oscarpalmer\Yogurt\Test;
 use oscarpalmer\Yogurt\Flavour;
 use oscarpalmer\Yogurt\Yogurt;
 
-class FlavourTest extends \PHPUnit_Framework_TestCase
+class FlavourTest extends \PHPUnit\Framework\TestCase
 {
     # Mock variables.
     protected $data;
@@ -80,6 +80,8 @@ class FlavourTest extends \PHPUnit_Framework_TestCase
         $flavour->data($this->data);
 
         $dataObject = $flavour->getDataObject();
+
+        $this->assertNotNull($dataObject);
     }
 
     public function testGetFilename()

--- a/tests/oscarpalmer/Yogurt/Test/YogurtTest.php
+++ b/tests/oscarpalmer/Yogurt/Test/YogurtTest.php
@@ -6,7 +6,7 @@ use oscarpalmer\Yogurt\Dairy;
 use oscarpalmer\Yogurt\Flavour;
 use oscarpalmer\Yogurt\Yogurt;
 
-class YogurtTest extends \PHPUnit_Framework_TestCase
+class YogurtTest extends \PHPUnit\Framework\TestCase
 {
     # Mock variables.
     protected $directory;


### PR DESCRIPTION
It's been a while, so a few things needed an update:

- Added support for `7.0` and `7.1.`
- Switched from Coveralls to Codecov for code coverage
- Fixed PHPUnit namespaces

Tests passes on `>=5.3`.